### PR TITLE
Switching to prod db

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,8 @@
             var selectedFlag = 'img/flags/us.png';
 
             var options = {
-                //serverUrl: "http://browser.ihtsdotools.org:3000",
-                serverUrl: "http://107.170.33.116:3000",
+                serverUrl: "http://browser.ihtsdotools.org:3000",
+                //serverUrl: "http://107.170.33.116:3000",
                 edition: "en-edition",
                 release: "v20140131",
                 showIds: false,


### PR DESCRIPTION
The browser was left aiming to the dvelopment database after last update. This pull will fix that by redirecting it to the production database.
