### PR TITLE
Added compositional grammar style rendering in concept summary

### DIFF
--- a/views/conceptDetailsPlugin/tabs/home/attributes.hbs
+++ b/views/conceptDetailsPlugin/tabs/home/attributes.hbs
@@ -23,4 +23,5 @@
 </h4>
 
 <h5>SCTID: {{firstMatch.conceptId}}</h5>
+<h5>{{firstMatch.conceptId}} | {{firstMatch.defaultTerm}} |</H5>
 <div id="home-descriptions-{{divElementId}}"></div>


### PR DESCRIPTION
As myself and I suppose others often have the need to copy compositional grammar style rendering (e.g. 404684003 | Clinical finding (finding) | ) of concepts to paste into documents, expressions etc. Much could probably be done with the appearance. It should though be put in some container which allows quick selection of the whole expression, e.g. by triple clicking.

Some examples:
![image](https://cloud.githubusercontent.com/assets/2042998/9003042/d2828010-376a-11e5-8649-597aaa8adcaf.png)
![image](https://cloud.githubusercontent.com/assets/2042998/9003095/3e8380e8-376b-11e5-9262-aed7db0992df.png)

